### PR TITLE
Adds strict locals snippet introduced in rails 7.1

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -5,6 +5,12 @@
 		"description": "commented ERB tags",
 		"scope": "text.html.ruby"
 	},
+  "lmc": {
+    "prefix": "lmc",
+    "body": "<%# locals: ($0) -%>",
+    "description": "Rails strict locals magic comment",
+    "scope": "text.html.ruby"
+  },
 	"each": {
 		"prefix": "each",
 		"body": "\n<% ${1:@things}.each do |${2:thing}| %>\n\t$0\n<% end %>\n",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -5,12 +5,12 @@
 		"description": "commented ERB tags",
 		"scope": "text.html.ruby"
 	},
-  "lmc": {
-    "prefix": "lmc",
-    "body": "<%# locals: ($0) -%>",
-    "description": "Rails strict locals magic comment",
-    "scope": "text.html.ruby"
-  },
+	"lmc": {
+		"prefix": "lmc",
+		"body": "<%# locals: ($0) -%>",
+		"description": "Rails strict locals magic comment",
+		"scope": "text.html.ruby"
+	},
 	"each": {
 		"prefix": "each",
 		"body": "\n<% ${1:@things}.each do |${2:thing}| %>\n\t$0\n<% end %>\n",


### PR DESCRIPTION
In Rails 7.1 a [new magic comment syntax ](https://blog.kiprosh.com/allow-template-to-set-strict-locals/) was added for strict locals in templates.

This adds a snippet to populate it to the extension.